### PR TITLE
[feat] #4 #5 카카오 소셜 로그인 구현 (1/2)

### DIFF
--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -16,9 +16,33 @@ export class UserController {
       'http://localhost:3333/user/callback/naver' +
       '&state=' +
       'RANDOM_STATE';
+
+    const kakaoOauthUrl = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.KAKAO_REST_API_KEY}&redirect_uri=http://localhost:3333/user/callback/kakao&response_type=code`;
     switch (social) {
       case socialPlatform.NAVER:
         res.redirect(naverOauthUrl);
+        break;
+      case socialPlatform.KAKAO:
+        res.redirect(kakaoOauthUrl);
+        break;
+    }
+  }
+
+  @Get('callback/kakao')
+  async kakaoCallback(@Query('code') code: string, @Res() res: Response) {
+    const access_token = await this.userService.kakaoOauth(code);
+    const kakaoProfile = await this.userService.kakaoProfileSearch(
+      access_token
+    );
+    console.log(kakaoProfile);
+    const userData = await this.userService.findUser(
+      socialPlatform.KAKAO,
+      kakaoProfile.id
+    );
+    if (userData == null) {
+      return res.redirect('http://localhost:3333/user'); // 가입으로 보내요
+    } else {
+      return res.redirect('http://naver.com'); // 쿠기 생성해서 메인으로 보내요
     }
   }
 

--- a/backend/src/user/user.enum.ts
+++ b/backend/src/user/user.enum.ts
@@ -1,5 +1,5 @@
 export enum socialPlatform {
   NAVER = 'naver',
-  KAKAO = 'kokao',
+  KAKAO = 'kakao',
   GOOGLE = 'google',
 }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -19,6 +19,16 @@ export class UserService {
     return saveResult;
   }
 
+  async kakaoOauth(code: string) {
+    const api_url = `https://kauth.kakao.com/oauth/token?grant_type=authorization_code&client_id=${process.env.KAKAO_REST_API_KEY}&redirect_url=http://localhost:3333/user/callback/kakao&code=${code}`;
+
+    const kakaoOauthResponse = await firstValueFrom(
+      this.httpService.post(api_url)
+    );
+    const access_token = kakaoOauthResponse.data.access_token;
+    return access_token;
+  }
+
   async naverOauth(code: string, state: string) {
     const api_url =
       'https://nid.naver.com/oauth2.0/token?grant_type=authorization_code&client_id=' +
@@ -45,8 +55,32 @@ export class UserService {
     return access_token;
   }
 
+  async kakaoProfileSearch(access_token: string) {
+    console.log(access_token);
+    try {
+      const kakaoProfileApiResponse = await firstValueFrom(
+        this.httpService.get('https://kapi.kakao.com/v2/user/me', {
+          headers: {
+            Authorization: 'Bearer ' + access_token,
+            'Content-type': 'application/x-www-form-urlencoded;charset=utf-8',
+          },
+        })
+      );
+
+      const id = kakaoProfileApiResponse.data.id;
+      const email = kakaoProfileApiResponse.data.kakao_account.email;
+      const profile_image =
+        kakaoProfileApiResponse.data.kakao_account.profile.profile_image_url;
+      return { id, email, profile_image };
+    } catch (e) {
+      console.log(e);
+      return;
+    }
+  }
+
   async naverProfileSearch(access_token: string) {
     const url = 'https://openapi.naver.com/v1/nid/me';
+
     const naverProfileApiResponse = await firstValueFrom(
       this.httpService.get(url, {
         headers: {
@@ -56,7 +90,6 @@ export class UserService {
     );
 
     const { id, profile_image, email } = naverProfileApiResponse.data.response;
-    console.log();
     return { id, profile_image, email };
   }
 


### PR DESCRIPTION
## 📕 제목

카카오 소셜 로그인 구현 (1/2) #4 #5 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- kakao Oauth를 통해 유저 accessToken 받기
- kakao Profile 조회 api 를 통해 유저 정보 받기
- 받은 user id로 기존 유저인지 식별 후 redirect 제공


## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 없음
