### PR TITLE
phaser(canvas) 사이즈 버그 개선

### DIFF
--- a/frontend/src/component/Game/gameConfig.ts
+++ b/frontend/src/component/Game/gameConfig.ts
@@ -5,7 +5,7 @@ const gameConfig: Phaser.Types.Core.GameConfig = {
   type: Phaser.AUTO,
   pixelArt: true,
   scale: {
-    mode: Phaser.Scale.FIT,
+    mode: Phaser.Scale.RESIZE,
     autoCenter: Phaser.Scale.CENTER_BOTH,
     width: '100%',
     height: '100%',

--- a/frontend/src/global.ts
+++ b/frontend/src/global.ts
@@ -17,6 +17,10 @@ export const global = css`
     overflow: hidden;
   }
 
+  canvas {
+    margin: 0 !important;
+  }
+
   .srOnly {
     overflow: hidden;
     position: absolute !important;


### PR DESCRIPTION
## 📕 제목

#36 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- 창 크기를 줄였다가 늘리는 경우 phaser로 그린 canvas가 줄어든 상태인 것을 개선(mode 변경)
- global css에 top margin을 지워주기 위해 margin을 0으로 설정

