### PR TITLE
팔로우 기능 완성

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,8 @@ import { User } from './auth/entity/user.entity';
 import { BoardModule } from './board/board.module';
 import { BoardLike } from './board/entity/board-like.entity';
 import { Board } from './board/entity/board.entity';
+import { Following } from './friendship/entity/follwing.entity';
+import { FriendshipModule } from './friendship/friendship.module';
 
 @Module({
   imports: [
@@ -18,12 +20,13 @@ import { Board } from './board/entity/board.entity';
         username: process.env.DB_ID,
         password: process.env.DB_PASSWORD,
         database: process.env.DB_NAME,
-        entities: [User, Board, BoardLike],
+        entities: [User, Board, BoardLike, Following],
         synchronize: true,
       }),
     }),
     AuthModule,
     BoardModule,
+    FriendshipModule,
   ],
   controllers: [],
   providers: [],

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -20,7 +20,7 @@ import { UserService } from './user.service';
       inject: [ConfigService],
       useFactory: (config: ConfigService) => ({
         secret: config.get<string>('JWT_SECRET_KEY'),
-        signOptions: { expiresIn: '60m' },
+        signOptions: { expiresIn: '1d' },
       }),
     }),
   ],

--- a/backend/src/auth/entity/user.entity.ts
+++ b/backend/src/auth/entity/user.entity.ts
@@ -1,6 +1,7 @@
 import { BoardLike } from 'src/board/entity/board-like.entity';
 import { Board } from 'src/board/entity/board.entity';
-import { Column, Entity, JoinColumn, OneToMany, PrimaryColumn } from 'typeorm';
+import { Following } from 'src/friendship/entity/follwing.entity';
+import { Column, Entity, OneToMany, PrimaryColumn } from 'typeorm';
 import { socialPlatform } from '../user.enum';
 
 @Entity('user')
@@ -39,4 +40,10 @@ export class User {
 
   @OneToMany(() => BoardLike, like => like.board)
   likes: BoardLike[];
+
+  @OneToMany(() => Following, following => following.userId)
+  following: Following[];
+
+  @OneToMany(() => Following, following => following.targetUserId)
+  followedBy: Following[];
 }

--- a/backend/src/auth/user.service.ts
+++ b/backend/src/auth/user.service.ts
@@ -35,4 +35,15 @@ export class UserService {
       );
     }
   }
+
+  async getUserIdByNickname(nickname: string): Promise<string> {
+    try {
+      const userData = await this.userRepository.findOneBy({ nickname });
+      return userData.id;
+    } catch (e) {
+      throw new NotFoundException(
+        '해당 닉네임을 가진 유저를 찾을 수 없습니다.'
+      );
+    }
+  }
 }

--- a/backend/src/friendship/entity/follwing.entity.ts
+++ b/backend/src/friendship/entity/follwing.entity.ts
@@ -1,0 +1,21 @@
+import { User } from 'src/auth/entity/user.entity';
+import { Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+
+@Entity('following')
+export class Following {
+  @PrimaryColumn()
+  userId: string;
+
+  @PrimaryColumn()
+  targetUserId: string;
+
+  @ManyToOne(() => User, user => user.following, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @ManyToOne(() => User, user => user.followedBy, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'targetUserId' })
+  targetUser: User;
+}

--- a/backend/src/friendship/friendship.controller.ts
+++ b/backend/src/friendship/friendship.controller.ts
@@ -1,0 +1,65 @@
+import {
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Put,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { UserService } from 'src/auth/user.service';
+import { FriendshipService } from './friendship.service';
+
+@Controller('friendship')
+@UseGuards(AuthGuard('criticalGuard'))
+export class FriendshipController {
+  constructor(
+    private readonly friendshipService: FriendshipService,
+    private readonly userService: UserService
+  ) {}
+
+  @Get()
+  async getFollowingList(@Req() req: any) {
+    const { id } = req.user;
+    const followingList = await this.friendshipService.getFollowingList(id);
+    return followingList;
+  }
+
+  // PUT friendship 요청
+  @Put('/:targetNickname')
+  async followFriend(
+    @Req() req: any,
+    @Param('targetNickname') targetNickname: string
+  ) {
+    const { id } = req.user;
+    const targetUserId = await this.userService.getUserIdByNickname(
+      targetNickname
+    );
+    const result = await this.friendshipService.followFriend(id, targetUserId);
+
+    return result ? '팔로우 성공' : '팔로우 실패';
+    // 404 -> 없는 놈임
+  }
+  @Delete('/:targetNickname')
+  async unfollowFriend(
+    @Req() req: any,
+    @Param('targetNickname') targetNickname: string
+  ) {
+    const { id } = req.user;
+
+    const targetUserId = await this.userService.getUserIdByNickname(
+      targetNickname
+    );
+    const result = await this.friendshipService.unfollowFriend(
+      id,
+      targetUserId
+    );
+
+    return result ? '팔로우 취소 성공' : '팔로우 목록에 없는 유저';
+    // delete
+  }
+}
+
+// 없는놈 404
+// 잇는놈

--- a/backend/src/friendship/friendship.module.ts
+++ b/backend/src/friendship/friendship.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from 'src/auth/entity/user.entity';
+import { UserService } from 'src/auth/user.service';
+import { Following } from './entity/follwing.entity';
+import { FriendshipController } from './friendship.controller';
+import { FriendshipService } from './friendship.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User, Following])],
+  controllers: [FriendshipController],
+  providers: [FriendshipService, UserService],
+})
+export class FriendshipModule {}

--- a/backend/src/friendship/friendship.service.ts
+++ b/backend/src/friendship/friendship.service.ts
@@ -1,0 +1,61 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { User } from 'src/auth/entity/user.entity';
+import { Repository } from 'typeorm';
+import { Following } from './entity/follwing.entity';
+
+@Injectable()
+export class FriendshipService {
+  constructor(
+    @InjectRepository(Following)
+    private followingRepository: Repository<Following>
+  ) {}
+
+  async getFollowingList(userId: string): Promise<User[]> {
+    // following테이블의 userId 컬럼이 user테이블의 id랑  natural join 데이터에서ㅡ nickcolumn만 select
+    try {
+      const resultList = await this.followingRepository
+        .createQueryBuilder('following')
+        .innerJoinAndSelect('following.targetUser', 'user')
+        .where('following.userId = :userId', { userId })
+        .getMany();
+
+      const followingList = resultList.map(result => result.targetUser);
+      return followingList;
+    } catch (e) {
+      throw new NotFoundException('팔로잉 목록 조회 오류');
+    }
+  }
+  async followFriend(userId: string, targetUserId: string) {
+    try {
+      //팔로잉 처리 처리
+      const insertResult = await this.followingRepository
+        .createQueryBuilder()
+        .insert()
+        .into(Following)
+        .values({ userId, targetUserId })
+        .execute();
+
+      return insertResult.identifiers.length ? true : false;
+    } catch (e) {
+      throw new NotFoundException('이미 팔로우한 유저입니다.');
+    }
+  }
+
+  async unfollowFriend(userId: string, targetUserId: string) {
+    try {
+      const deleteResult = await this.followingRepository
+        .createQueryBuilder()
+        .delete()
+        .from(Following)
+        .where('userId = :userId AND targetUserId = :targetUserId', {
+          userId,
+          targetUserId,
+        })
+        .execute();
+      return deleteResult.affected ? true : false;
+    } catch (e) {
+      throw new NotFoundException('팔로우 취소 실패');
+    }
+  }
+}


### PR DESCRIPTION
## 📕 제목

PR 제목
팔로우 기능 완성

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

### 팔로우 목록 조회
   - API `GET` `/friendship`
   - 결과
   ```
    [{ // 팔로잉 2명
        "id": "2526670883",
        "nickname": "hungjin",
        "characterName": "lion",
        "social": "kakao",
        "created_at": "2022-11-15",
        "deleted": false
    },
    {
        "id": "IZI_1Wzwhqblu0A4KA_TCrtkl4mM55Qstc_FDKMv_sY",
        "nickname": "hj",
        "characterName": "lion",
        "social": "naver",
        "created_at": "2022-11-15",
        "deleted": false
    }]
   ```
   ```
    []// 팔로잉 0명
   ```

### 닉네임으로 팔로우 신청
  - API `PUT` `/friendship/상대닉네임`
 - 성공
 ```팔로우 성공 (200)```
 - 실패
   ```
   {
        "statusCode": 404,
        "message": "이미 팔로우한 유저입니다.",
        "error": "Not Found"
   }
   ```

### 닉네임으로 팔로우 취소
   - API `DELETE` `/friendship/상대닉네임` 
   - 성공
   ```팔로우 취소 성공 (200)```
   - 실패
   ```팔로우 목록에 없는 유저 (200)```

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 팔로우 취소 부분에서 실패했을 때, 200으로 반환하는 게 좋을까요? 404 등으로 반환하는 게 좋을까요?
