### PR TITLE
Socket을 통한 채팅 구현 및 DB 리팩토링

### DIFF
--- a/backend/src/auth/entity/user.entity.ts
+++ b/backend/src/auth/entity/user.entity.ts
@@ -6,15 +6,18 @@ import { socialPlatform } from '../user.enum';
 
 @Entity('user')
 export class User {
-  @PrimaryColumn()
+  @PrimaryColumn('varchar', { length: 64 })
   id: string;
 
-  @Column({
+  @Column('char', {
+    length: 16,
     unique: true,
   })
   nickname: string;
 
-  @Column()
+  @Column('char', {
+    length: 16,
+  })
   characterName: string;
 
   @Column({

--- a/backend/src/board/entity/board-like.entity.ts
+++ b/backend/src/board/entity/board-like.entity.ts
@@ -4,7 +4,7 @@ import { Board } from './board.entity';
 
 @Entity('board_like')
 export class BoardLike {
-  @PrimaryColumn()
+  @PrimaryColumn('varchar', { length: 64 })
   userId: string;
 
   @PrimaryColumn()

--- a/backend/src/board/entity/board.entity.ts
+++ b/backend/src/board/entity/board.entity.ts
@@ -17,10 +17,10 @@ export class Board {
   })
   id: number;
 
-  @Column()
+  @Column('varchar', { length: 64 })
   userId: string;
 
-  @Column()
+  @Column('varchar', { length: 128 })
   content: string;
 
   @Column({

--- a/backend/src/friendship/entity/follwing.entity.ts
+++ b/backend/src/friendship/entity/follwing.entity.ts
@@ -3,10 +3,10 @@ import { Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
 
 @Entity('following')
 export class Following {
-  @PrimaryColumn()
+  @PrimaryColumn('varchar', { length: 64 })
   userId: string;
 
-  @PrimaryColumn()
+  @PrimaryColumn('varchar', { length: 64 })
   targetUserId: string;
 
   @ManyToOne(() => User, user => user.following, { onDelete: 'CASCADE' })

--- a/backend/src/socket/socket.gateway.ts
+++ b/backend/src/socket/socket.gateway.ts
@@ -22,9 +22,7 @@ export class SocketGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   constructor(private readonly authService: AuthService) {}
 
-  // 입장 햇을 시
-
-  public getRoomUserData(roomName) {
+  public getRoomUserData(roomName: string) {
     const roomUser = [];
     this.server.sockets.adapter.rooms.get(roomName).forEach(e => {
       roomUser.push(this.server.sockets.sockets.get(e)['userData']);
@@ -32,9 +30,10 @@ export class SocketGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
     return roomUser;
   }
+
   public handleConnection(client: Socket): void {
     const key = client.handshake.headers.authorization;
-    const roomName = client.handshake.headers.room;
+    const roomName = client.handshake.headers.room.toString();
     const userData = this.authService.verify(key);
     if (!userData || !roomName) {
       client.disconnect();
@@ -58,9 +57,8 @@ export class SocketGateway implements OnGatewayConnection, OnGatewayDisconnect {
       .emit('userCreated', this.getRoomUserData(roomName));
   }
 
-  // 퇴장 햇을 시
   public handleDisconnect(client: Socket): void {
-    this.server.emit('userLeaved', client.id);
+    this.server.emit('userLeaved', client['userData']['id']);
   }
 
   @UsePipes(new ValidationPipe())
@@ -74,9 +72,28 @@ export class SocketGateway implements OnGatewayConnection, OnGatewayDisconnect {
     client.to(client['userData']['roomName']).emit('move', client['userData']);
   }
 
-  @SubscribeMessage('message')
-  handleMessage(client: any, payload: any): string {
-    console.log('hi');
-    return 'Hello world!';
+  // 전체채팅
+  @SubscribeMessage('chat')
+  handleMessage(client: any, payload: any): void {
+    const msgPayload = {
+      fromUserId: client['userData']['id'],
+      timestamp: Date.now(),
+      message: payload['message'] || '',
+    };
+
+    client.to(client['userData']['roomName']).emit('chat', msgPayload);
+  }
+
+  @SubscribeMessage('directMessage')
+  handleDirectMessage(client: any, payload: any): void {
+    const targetUserId = payload['targetUserId'];
+    const targetSockeitId = payload['targetSocketId'];
+
+    const msgPayload = {
+      fromUserId: client['userData']['id'],
+      timestamp: Date.now(),
+      message: payload['message'] || '',
+    };
+    client.to(targetSockeitId).emit('directMessage', msgPayload);
   }
 }


### PR DESCRIPTION

## 📕 제목
- #3 
- #51 
- #93 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 소켓을 통한 채팅 구현
  - room내에서 전체채팅(chat)
  - 개인메시지(directMessage)
- [x] 소켓 관리방식 변경
  - 서버측에서 user에 해당하는 socketID 유지
  - 중복 접속 방지
- [x] DB리팩토링
  - 데이터타입 구체화

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 없음
