### PR TITLE
채팅방목록, 친구 추가, 게시글목록 반환값 수정

### DIFF
--- a/backend/src/board/board.service.ts
+++ b/backend/src/board/board.service.ts
@@ -51,7 +51,10 @@ export class BoardService {
           ? []
           : await this.friendshipService.getFollowingList(userId);
 
-      const followingIdList = [userId, ...followingList.map(user => user.id)];
+      const followingIdList = [
+        userId,
+        ...followingList.map(user => user.userId),
+      ];
       const articleList = await this.boardRepository
         .createQueryBuilder('board')
         .select([
@@ -61,8 +64,12 @@ export class BoardService {
           'board.content as content',
           'board.category as category',
           'board.created_at as created_at',
+          'CASE WHEN boardLike.articleId is null THEN false ELSE true END AS liked',
         ])
         .innerJoin('board.user', 'user')
+        .leftJoin('board.likes', 'boardLike', 'boardLike.userId = :userId', {
+          userId,
+        })
         .where('board.userId IN (:...list) AND board.deleted = false', {
           list: followingIdList,
         })

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -43,6 +43,10 @@ export class ChatService {
         .where('chatMark.userId=:userId', { userId })
         .getRawMany();
 
+      if (chatRoomList.length == 0) {
+        return [];
+      }
+
       const roomIdList = chatRoomList.map(chatRoom => chatRoom.roomId);
       const friendList = await this.chatMarkRepository
         .createQueryBuilder('chatMark')

--- a/backend/src/friendship/friendship.controller.ts
+++ b/backend/src/friendship/friendship.controller.ts
@@ -48,8 +48,11 @@ export class FriendshipController {
       targetNickname
     );
     await this.friendshipService.followFriend(userId, targetUserId);
-
-    return '팔로우 성공';
+    const followingList = await this.friendshipService.getFollowingList(userId);
+    return followingList.map(following => {
+      const { nickname, characterName } = following;
+      return { nickname, characterName };
+    });
   }
 
   @Delete('/:targetNickname')
@@ -63,7 +66,10 @@ export class FriendshipController {
       targetNickname
     );
     await this.friendshipService.unfollowFriend(userId, targetUserId);
-
-    return '팔로우 취소 성공';
+    const followingList = await this.friendshipService.getFollowingList(userId);
+    return followingList.map(following => {
+      const { nickname, characterName } = following;
+      return { nickname, characterName };
+    });
   }
 }

--- a/backend/src/friendship/friendship.controller.ts
+++ b/backend/src/friendship/friendship.controller.ts
@@ -24,10 +24,7 @@ export class FriendshipController {
   async getFollowingList(@Req() req: any) {
     const userId = req.user.id;
     const followingList = await this.friendshipService.getFollowingList(userId);
-    return followingList.map(following => {
-      const { nickname, characterName } = following;
-      return { nickname, characterName };
-    });
+    return followingList;
   }
 
   @Get('/:searchNickname')
@@ -49,10 +46,9 @@ export class FriendshipController {
     );
     await this.friendshipService.followFriend(userId, targetUserId);
     const followingList = await this.friendshipService.getFollowingList(userId);
-    return followingList.map(following => {
-      const { nickname, characterName } = following;
-      return { nickname, characterName };
-    });
+    return followingList.find(
+      following => following.nickname === targetNickname
+    );
   }
 
   @Delete('/:targetNickname')
@@ -66,10 +62,6 @@ export class FriendshipController {
       targetNickname
     );
     await this.friendshipService.unfollowFriend(userId, targetUserId);
-    const followingList = await this.friendshipService.getFollowingList(userId);
-    return followingList.map(following => {
-      const { nickname, characterName } = following;
-      return { nickname, characterName };
-    });
+    return '팔로우 취소 성공';
   }
 }

--- a/backend/src/friendship/friendship.service.ts
+++ b/backend/src/friendship/friendship.service.ts
@@ -11,7 +11,7 @@ export class FriendshipService {
     private followingRepository: Repository<Following>
   ) {}
 
-  async getFollowingList(userId: string): Promise<User[]> {
+  async getFollowingList(userId: string): Promise<any[]> {
     // following테이블의 userId 컬럼이 user테이블의 id랑  natural join 데이터에서ㅡ nickcolumn만 select
     try {
       const resultList = await this.followingRepository
@@ -20,9 +20,14 @@ export class FriendshipService {
         .where('following.userId = :userId AND user.deleted = false', {
           userId,
         })
-        .getMany();
-
-      const followingList = resultList.map(result => result.targetUser);
+        .getRawMany();
+      const followingList = resultList.map(result => {
+        return {
+          userId: result.user_id,
+          nickname: result.user_nickname,
+          characterName: result.user_characterName,
+        };
+      });
       return followingList;
     } catch (e) {
       throw new NotFoundException('팔로잉 목록 조회 오류');


### PR DESCRIPTION


## 📕 제목

- #3 
- #50 
- #66 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 채팅방 목록의 리턴값
  - 개설된 채팅방이 없을시, 백엔드쪽 코드에서 아직 선언되지 않은 변수에 map접근을 시도하면서 error를 반환하던 것을 빈배열 반환하는 것으로 변경함
- [x] 친구 목록의 리턴값
  - 기존 nickname, characterName에서, userId까지 함께 리턴
- [x] 친구 추가 성공시의 리턴값
  - 친구 추가 성공시 해당 유저의 유저데이터(userId, nickname, characterName)을 반환하도록 함
  - ```json
    {
       "userId": "Z-NVwpPpbw7oOjHEn-CYEZ8V9nU3P9IIChz_9PuuVak",
       "nickname": "j002",
       "characterName": "mophair"
    }
- [x] 게시글 목록 반환시의 리턴값
  - 게시글 목록에서 게시글 자료구조에 좋아요여부 필드 `liked` 추가
  - ```json
    [
     {
        "id": 2,
        "nickname": "jongbin",
        "userid": "1NJfqr-aPPEfIJPIvFNd6OzG8qFqTUSRNbT7bxM24R0",
        "content": "헬로우~",
        "category": "fishing",
        "created_at": "2022-12-01T05:20:56.815Z",
        "liked": false
    },
    {
        "id": 1,
        "nickname": "hjin",
        "userid": "IZI_1Wzwhqblu0A4KA_TCrtkl4mM55Qstc_FDKMv_sY",
        "content": "안녕하세요!",
        "category": "fishing",
        "created_at": "2022-12-01T05:20:56.815Z",
        "liked": true
     }
    ]

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 없음
