### PR TITLE
채팅방 목록 배열 반환값 구체화

### DIFF
--- a/backend/src/chat/entity/chat-room.entity.ts
+++ b/backend/src/chat/entity/chat-room.entity.ts
@@ -13,7 +13,7 @@ export class ChatRoom {
   totalmsgcount: number;
 
   @OneToMany(() => Chat, chat => chat.room)
-  chatRoom: Chat[];
+  chats: Chat[];
 
   @OneToMany(() => ChatMark, mark => mark.room)
   chatMark: ChatMark[];

--- a/backend/src/chat/entity/chat.entity.ts
+++ b/backend/src/chat/entity/chat.entity.ts
@@ -30,7 +30,7 @@ export class Chat {
   @Column('varchar', { length: 256 })
   message: string;
 
-  @ManyToOne(() => ChatRoom, room => room.chatRoom)
+  @ManyToOne(() => ChatRoom, room => room.chats)
   @JoinColumn({ name: 'roomId' })
   room: ChatRoom;
 


### PR DESCRIPTION


## 📕 제목
 - #3 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] entity 필드명 명확하지 않은 것 수정
- [x] 채팅방 목록 배열 반환값 구체화
  - roomId : 채팅방 id
  - targetUserId : 채팅상대 유저식별 id
  - targerUserNickname : 채팅상대 닉네임
  - unReadCount : 읽지 않은 메시지 개수
  - lastMsg : 채팅방 마지막 메시지 데이터 object 
    - id : 메시지 id
    - timestamp : 메시지 발송 시간
    - message : 메시지 내용
  - ```javascript
    [
     {
       // socket -  chatRoomEntered 이벤트로 인해, 내부적으로 채팅방 생성이 되었지만 메시지 수발신이 없었던 채팅방
       // 메시지 수발신이 없었기 때문에 lastMsg필드가 없습니다 
       "roomId": 10,
       "targetUserId": "9B8X7YWtA0XlNTBzCItRGmLlUKBYkHdshMPqtsE7sWE",
       "targetUserNickname": "ktmihs",
       "unReadCount": 0
     },
     {
       "roomId": 1,
       "targetUserId": "Z-NVwpPpbw7oOjHEn-CYEZ8V9nU3P9IIChz_9PuuVak",
       "targetUserNickname": "j002",
       "unReadCount": 2,
       "lastMsg": {
           "id": 66,
           "timestamp": "2022-11-30T15:05:48.448Z",
           "message": "개인 메시지 입니다.."
       }
     }
    ]
 
## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 채팅방이 개설만 되었고 메시지 수발신이 전혀 없었던 경우 obj내 lastMsg key 자체가 없습니다. (예시를 참고해주세요!)
