### PR TITLE
게임페이지에서 town으로 돌아가는 포탈 생성 및 버그 수정

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,13 +1,21 @@
 <!DOCTYPE html>
 <html lang="ko">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>SleepyWoods</title>
-  </head>
 
-  <body>
-    <div id="root"></div>
-    <script type="module" src="./src/index.tsx"></script>
-  </body>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+  <script type="text/javascript">
+    document.oncontextmenu = function () {
+      return false;
+    }
+  </script>
+  <title>SleepyWoods</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="./src/index.tsx"></script>
+</body>
+
 </html>

--- a/frontend/src/component/Game/Phaser/Player/myPlayer.ts
+++ b/frontend/src/component/Game/Phaser/Player/myPlayer.ts
@@ -47,6 +47,7 @@ export class MyPlayer extends Player {
 
   update() {
     const prevState = this.state;
+    const prevPos = { x: this.x, y: this.y };
 
     if (!this.isCanMove) {
       this.state = 'wait';
@@ -112,12 +113,15 @@ export class MyPlayer extends Player {
     if (prevState !== this.state) changeState(this);
 
     if (prevState !== this.state || this.heldDirection.length) {
-      this.socket.emit('move', {
-        state: this.state,
-        direction: this.direction,
-        x: this.x,
-        y: this.y,
-      });
+      this.socket.emit(
+        prevPos.x !== this.x || prevPos.y !== this.y ? 'move' : 'motion',
+        {
+          state: this.state,
+          direction: this.direction,
+          x: this.x,
+          y: this.y,
+        }
+      );
     }
   }
 }

--- a/frontend/src/component/Game/Scene/sprint.ts
+++ b/frontend/src/component/Game/Scene/sprint.ts
@@ -1,11 +1,19 @@
+import { Socket } from 'socket.io-client';
 import { MyPlayer } from '../Phaser/Player/myPlayer';
 import { OtherPlayer } from '../Phaser/Player/otherPlayer';
+import { emitter } from '../util';
+
+const backToTown = { x: 1600, y: 1900 };
 
 export default class Sprint extends Phaser.Scene {
+  socket?: Socket;
+  autoPlay?: boolean;
   background?: Phaser.Tilemaps.TilemapLayer;
   otherLayer?: Phaser.Tilemaps.TilemapLayer;
   myPlayer?: MyPlayer;
   otherPlayer: { [key: string]: OtherPlayer };
+  gameEntry?: any;
+  isEnterGameZone?: any;
 
   constructor() {
     super('Sprint');
@@ -23,6 +31,54 @@ export default class Sprint extends Phaser.Scene {
       data.myPlayer.nickname,
       data.socket
     );
+
+    this.gameEntry = this.physics.add.staticGroup({
+      key: 'portal',
+      frameQuantity: 1,
+    });
+
+    this.gameEntry
+      .getChildren()[0]
+      .setPosition(backToTown.x, backToTown.y)
+      .setDepth(3);
+
+    this.gameEntry.refresh();
+
+    const keyG = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.G);
+
+    this.physics.add.overlap(this.myPlayer, this.gameEntry, () => {
+      const { x, y } = backToTown;
+      const text: (
+        | Phaser.GameObjects.Graphics
+        | Phaser.GameObjects.Text
+        | undefined
+      )[] = [];
+
+      if (!this.isEnterGameZone) {
+        text.push(
+          this.add
+            .graphics()
+            .fillStyle(0xffffff, 50)
+            .fillRoundedRect(x - 140, y - 70, 265, 40, 20),
+          this.add.text(x - 130, y - 60, 'push G key for back to Town!', {
+            color: '#000',
+            font: '700 18px Arial',
+          })
+        );
+
+        this.isEnterGameZone = true;
+
+        setTimeout(() => {
+          text[0]?.destroy();
+          text[1]?.destroy();
+          this.isEnterGameZone = false;
+        }, 500);
+      }
+
+      if (Phaser.Input.Keyboard.JustDown(keyG)) {
+        this.changeScene('Town');
+      }
+    });
   }
 
   create() {
@@ -52,4 +108,15 @@ export default class Sprint extends Phaser.Scene {
   update() {
     this.myPlayer?.update();
   }
+
+  changeScene = (gameName: string) => {
+    emitter.emit('closeContent');
+
+    this.scene.pause();
+    this.scene.start(gameName, {
+      socket: this.socket,
+      myPlayer: this.myPlayer,
+      autoPlay: this.autoPlay,
+    });
+  };
 }

--- a/frontend/src/component/Game/Scene/town.ts
+++ b/frontend/src/component/Game/Scene/town.ts
@@ -27,7 +27,6 @@ export default class Town extends Phaser.Scene {
 
   init() {
     emitter.on('gameStart', (data: any) => {
-      console.log(data.userList);
       this.changeScene(data.gameName);
     });
 
@@ -136,13 +135,24 @@ export default class Town extends Phaser.Scene {
   }
 
   changeScene = (gameName: string) => {
-    console.log(gameName);
+    emitter.emit('closeContent');
+
     this.scene.pause();
     this.scene.start(gameName, {
       socket: this.socket,
       myPlayer: this.myPlayer,
       autoPlay: this.autoPlay,
     });
+
+    // 자신의 캐릭터 지워주기
+    this.myPlayer?.delete();
+    delete this.myPlayer;
+
+    // emitter 이벤트 지워주기
+    emitter.removeListener('init');
+    emitter.removeListener('updateNickname');
+    emitter.removeListener('updateHair');
+    emitter.removeListener('gameStart');
   };
 
   create() {
@@ -243,6 +253,14 @@ export default class Town extends Phaser.Scene {
     });
 
     this.socket.on('move', (data: userType) => {
+      const id = data.id.toString().trim();
+
+      if (!this.otherPlayer[id]) return;
+      const { state, x, y, direction } = data;
+      this.otherPlayer[id].update(state, x, y, direction);
+    });
+
+    this.socket.on('motion', (data: userType) => {
       const id = data.id.toString().trim();
 
       if (!this.otherPlayer[id]) return;

--- a/frontend/src/component/Game/Scene/zombie.ts
+++ b/frontend/src/component/Game/Scene/zombie.ts
@@ -1,11 +1,19 @@
+import { Socket } from 'socket.io-client';
 import { MyPlayer } from '../Phaser/Player/myPlayer';
 import { OtherPlayer } from '../Phaser/Player/otherPlayer';
+import { emitter } from '../util';
+
+const backToTown = { x: 1000, y: 1580 };
 
 export default class Zombie extends Phaser.Scene {
+  socket?: Socket;
+  autoPlay?: boolean;
   background?: Phaser.Tilemaps.TilemapLayer;
   otherLayer?: Phaser.Tilemaps.TilemapLayer;
   myPlayer?: MyPlayer;
   otherPlayer: { [key: string]: OtherPlayer };
+  gameEntry?: any;
+  isEnterGameZone?: any;
 
   constructor() {
     super('Zombie');
@@ -23,6 +31,54 @@ export default class Zombie extends Phaser.Scene {
       data.myPlayer.nickname,
       data.socket
     );
+
+    this.gameEntry = this.physics.add.staticGroup({
+      key: 'portal',
+      frameQuantity: 1,
+    });
+
+    this.gameEntry
+      .getChildren()[0]
+      .setPosition(backToTown.x, backToTown.y)
+      .setDepth(3);
+
+    this.gameEntry.refresh();
+
+    const keyG = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.G);
+
+    this.physics.add.overlap(this.myPlayer, this.gameEntry, () => {
+      const { x, y } = backToTown;
+      const text: (
+        | Phaser.GameObjects.Graphics
+        | Phaser.GameObjects.Text
+        | undefined
+      )[] = [];
+
+      if (!this.isEnterGameZone) {
+        text.push(
+          this.add
+            .graphics()
+            .fillStyle(0xffffff, 50)
+            .fillRoundedRect(x - 140, y - 70, 265, 40, 20),
+          this.add.text(x - 130, y - 60, 'push G key for back to Town!', {
+            color: '#000',
+            font: '700 18px Arial',
+          })
+        );
+
+        this.isEnterGameZone = true;
+
+        setTimeout(() => {
+          text[0]?.destroy();
+          text[1]?.destroy();
+          this.isEnterGameZone = false;
+        }, 500);
+      }
+
+      if (Phaser.Input.Keyboard.JustDown(keyG)) {
+        this.changeScene('Town');
+      }
+    });
   }
 
   create() {
@@ -56,4 +112,15 @@ export default class Zombie extends Phaser.Scene {
   update() {
     this.myPlayer?.update();
   }
+
+  changeScene = (gameName: string) => {
+    emitter.emit('closeContent');
+
+    this.scene.pause();
+    this.scene.start(gameName, {
+      socket: this.socket,
+      myPlayer: this.myPlayer,
+      autoPlay: this.autoPlay,
+    });
+  };
 }

--- a/frontend/src/component/MiniGame/index.tsx
+++ b/frontend/src/component/MiniGame/index.tsx
@@ -31,7 +31,13 @@ const MiniGame = () => {
       setSelectGame(gameName);
     });
 
+    emitter.on('closeContent', () => {
+      setIsShowModal(false);
+      initGame();
+    });
+
     return () => {
+      emitter.removeListener('closeContent');
       emitter.removeListener('game');
     };
   }, []);

--- a/frontend/src/component/Sidebar/index.tsx
+++ b/frontend/src/component/Sidebar/index.tsx
@@ -16,6 +16,7 @@ import Setting from './Setting';
 import Chat from './Chat';
 import { useRecoilState } from 'recoil';
 import { sidebarState } from '../../store/atom/sidebar';
+import { emitter } from '../Game/util';
 
 type componentType = {
   [key: string]: EmotionJSX.Element;
@@ -48,6 +49,16 @@ const Sidebar = () => {
       $img === target && setCurrentTab(name);
     });
   };
+
+  useEffect(() => {
+    emitter.on('closeContent', () => {
+      setOpen(false);
+    });
+
+    return () => {
+      emitter.removeListener('closeContent');
+    };
+  }, []);
 
   return (
     <aside css={sidebarWrapper(isOpen, currentTab)}>

--- a/frontend/src/component/SleepyBoard/index.tsx
+++ b/frontend/src/component/SleepyBoard/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { emitter } from '../Game/util';
 import RankContainer from './RankContainer';
 import * as style from './sleepyboard.styled';
 import SleepyBoardContainer from './SleepyBoardContainer';
@@ -18,6 +19,17 @@ const SleepyBoard = () => {
       setIsShowModal(true);
     }
   };
+
+  useEffect(() => {
+    emitter.on('closeContent', () => {
+      setAnimation('close');
+      setIsShowModal(false);
+    });
+
+    return () => {
+      emitter.removeListener('closeContent');
+    };
+  }, []);
 
   return (
     <>

--- a/frontend/src/page/Town/index.tsx
+++ b/frontend/src/page/Town/index.tsx
@@ -48,8 +48,8 @@ const Town = () => {
       <Sidebar />
       <Game />
       {isSnowing && <Snow />}
-      <SleepyBoard />
       <MiniGame />
+      <SleepyBoard />
       <Chat />
       <Info />
 


### PR DESCRIPTION
## 📕 제목

- #200 
- #199 
- #185 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- 제자리 걸음 벅스 수정
- 마우스 우클릭 막기
- scene 이동시 모달창, 사이드바 닫아주기
- 게임 입장시 town으로 돌아가는 포탈 생성

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이사항1
- 특이사항2
